### PR TITLE
Добавлен HTTP-сервер для отдачи котировок через эндпоинт /tickers

### DIFF
--- a/internal/server/http.go
+++ b/internal/server/http.go
@@ -1,0 +1,41 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/dimryb/cross-arb/internal/service"
+)
+
+type HTTPServer struct {
+	store *service.TickerStore
+}
+
+func NewHTTPServer(store *service.TickerStore) *HTTPServer {
+	return &HTTPServer{store: store}
+}
+
+func (s *HTTPServer) Run(addr string) error {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/tickers", s.handleTickers)
+
+	server := &http.Server{
+		Addr:         addr,
+		Handler:      mux,
+		ReadTimeout:  5 * time.Second,
+		WriteTimeout: 10 * time.Second,
+		IdleTimeout:  120 * time.Second,
+	}
+
+	return server.ListenAndServe()
+}
+
+func (s *HTTPServer) handleTickers(w http.ResponseWriter, _ *http.Request) {
+	tickers := s.store.GetAll()
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(tickers); err != nil {
+		http.Error(w, "internal server error", http.StatusInternalServerError)
+	}
+}

--- a/internal/service/arbitrage.go
+++ b/internal/service/arbitrage.go
@@ -14,10 +14,11 @@ import (
 )
 
 type Arbitrage struct {
-	ctx context.Context
-	app i.Application
-	log i.Logger
-	cfg *config.CrossArbConfig
+	ctx   context.Context
+	app   i.Application
+	log   i.Logger
+	cfg   *config.CrossArbConfig
+	store *TickerStore
 }
 
 func NewArbitrageService(
@@ -25,12 +26,14 @@ func NewArbitrageService(
 	app i.Application,
 	logger i.Logger,
 	cfg *config.CrossArbConfig,
+	store *TickerStore,
 ) *Arbitrage {
 	return &Arbitrage{
-		ctx: ctx,
-		app: app,
-		log: logger,
-		cfg: cfg,
+		ctx:   ctx,
+		app:   app,
+		log:   logger,
+		cfg:   cfg,
+		store: store,
 	}
 }
 

--- a/internal/service/arbitrage.go
+++ b/internal/service/arbitrage.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strconv"
 	"sync"
 	"time"
 
@@ -84,6 +85,16 @@ func (m *Arbitrage) Run() error {
 
 				fmt.Printf("=== Обновление цен (%s) ===\n", time.Now().Format("15:04:05.000"))
 				for _, r := range results {
+					if r.Error == nil {
+						m.store.Set(TickerData{
+							Symbol:   r.Data.Symbol,
+							Exchange: "mexc",
+							BidPrice: parseFloat(r.Data.BidPrice),
+							BidQty:   parseFloat(r.Data.BidQty),
+							AskPrice: parseFloat(r.Data.AskPrice),
+							AskQty:   parseFloat(r.Data.AskQty),
+						})
+					}
 					fmt.Printf(
 						"  [%s] -> покупка: %s (%s) продажа: %s (%s)\n",
 						r.Data.Symbol,
@@ -131,4 +142,9 @@ func bookTicker(sc *spotlist.SpotClient, symbol string) (BookTicker, error) {
 		return BookTicker{}, fmt.Errorf("failed to parse JSON: %w", err)
 	}
 	return tickerData, nil
+}
+
+func parseFloat(s string) float64 {
+	f, _ := strconv.ParseFloat(s, 64)
+	return f
 }

--- a/internal/service/store.go
+++ b/internal/service/store.go
@@ -1,0 +1,43 @@
+package service
+
+import (
+	"sync"
+)
+
+type TickerData struct {
+	Symbol   string  `json:"symbol"`
+	Exchange string  `json:"exchange"`
+	BidPrice float64 `json:"bidPrice"`
+	BidQty   float64 `json:"bidQty"`
+	AskPrice float64 `json:"askPrice"`
+	AskQty   float64 `json:"askQty"`
+}
+
+type TickerStore struct {
+	mu      sync.RWMutex
+	tickers map[string]TickerData
+}
+
+func NewTickerStore() *TickerStore {
+	return &TickerStore{
+		tickers: make(map[string]TickerData),
+	}
+}
+
+func (s *TickerStore) Set(t TickerData) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	key := t.Symbol + "-" + t.Exchange
+	s.tickers[key] = t
+}
+
+func (s *TickerStore) GetAll() []TickerData {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	all := make([]TickerData, 0, len(s.tickers))
+	for _, v := range s.tickers {
+		all = append(all, v)
+	}
+	return all
+}


### PR DESCRIPTION
Этот Pull Request включает реализацию HTTP-сервера, который предоставляет текущие котировки через эндпоинт `/tickers`. Основные изменения:

-  Добавлен потокобезопасный store для хранения тикеров.
- В структуру `Arbitrage` добавлен store.
- Реализовано сохранение котировок в store из сервиса.
- Запуск HTTP-сервера из `app`, настроен роут `/tickers` для получения актуальных данных.

Эти изменения позволяют получать котировки в реальном времени по HTTP, что упрощает интеграцию с другими сервисами и фронтендом.